### PR TITLE
Mqtt support with fixes and some more features

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,8 @@ pip3 install bleak
 ### Usage
 ```
 # daly-bms-cli --help
-usage: daly-bms-cli [-h] -d DEVICE [--uart] [--sinowealth] [--status] [--soc]
-                    [--mosfet] [--cell-voltages] [--temperatures]
-                    [--balancing] [--errors] [--all] [--check] [--retry RETRY]
-                    [--verbose]
+usage: daly-bms-cli [-h] -d DEVICE [--uart] [--sinowealth] [--status] [--soc] [--mosfet] [--cell-voltages] [--temperatures] [--balancing] [--errors] [--all] [--check] [--set-discharge-mosfet SET_DISCHARGE_MOSFET] [--retry RETRY] [--verbose] [--mqtt]
+                    [--mqtt-hass] [--mqtt-topic MQTT_TOPIC] [--mqtt-broker MQTT_BROKER] [--mqtt-port MQTT_PORT] [--mqtt-user MQTT_USER] [--mqtt-password MQTT_PASSWORD]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -67,8 +65,22 @@ optional arguments:
   --errors              show BMS errors
   --all                 show all
   --check               Nagios style check
+  --set-discharge-mosfet SET_DISCHARGE_MOSFET
+                        'on' or 'off'
   --retry RETRY         retry X times if the request fails, default 5
   --verbose             Verbose output
+  --mqtt                Write output to MQTT
+  --mqtt-hass           MQTT Home Assistant Mode
+  --mqtt-topic MQTT_TOPIC
+                        MQTT topic to write to. default daly_bms
+  --mqtt-broker MQTT_BROKER
+                        MQTT broker (server). default localhost
+  --mqtt-port MQTT_PORT
+                        MQTT port. default 1883
+  --mqtt-user MQTT_USER
+                        Username to authenticate MQTT with
+  --mqtt-password MQTT_PASSWORD
+                        Password to authenticate MQTT with
 ```
 
 ### Examples:

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -90,7 +90,7 @@ if args.mqtt:
 
 def print_result(result):
     if args.mqtt:
-        mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2))
+        mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2), qos=0, retain=True)
 
     print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -28,6 +28,7 @@ parser.add_argument("--retry", help="retry X times if the request fails, default
 parser.add_argument("--verbose", help="Verbose output", action="store_true")
 
 parser.add_argument("--mqtt", help="Write output to MQTT", action="store_true")
+parser.add_argument("--mqtt-hass", help="MQTT Home Assistant Mode", action="store_true")
 
 parser.add_argument("--mqtt-topic", 
                     help="MQTT topic to write to. default daly_bms", 
@@ -87,7 +88,11 @@ if args.mqtt:
 def print_result(result):
     if args.mqtt:
         for key in result.keys():
-            mqtt_client.publish("/".join((args.mqtt_topic, str(key))), result[key])
+            seq = (args.mqtt_topic, str(key))
+            if args.mqtt_hass:
+                seq = ("homeassistant", "sensor", args.mqtt_topic + "_" + str(key), "state")
+
+            mqtt_client.publish("/".join(seq), result[key])
 
     print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -30,8 +30,9 @@ parser.add_argument("--verbose", help="Verbose output", action="store_true")
 parser.add_argument("--mqtt", help="Write output to MQTT", action="store_true")
 
 parser.add_argument("--mqtt-topic", 
-                    help="MQTT topic to write to", 
-                    type=str)
+                    help="MQTT topic to write to. default daly_bms", 
+                    type=str,
+                    default="daly_bms")
 
 
 parser.add_argument("--mqtt-broker", 
@@ -144,6 +145,9 @@ if args.set_discharge_mosfet:
         sys.exit(1)
 
     result = bms.set_discharge_mosfet(on=on)
+
+if args.mqtt:
+    mqtt_client.disconnect()
 
 if not result:
     sys.exit(1)

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -115,7 +115,7 @@ def build_mqtt_hass_config_discovery(base):
     hass_config_data["state_topic"] = f'{args.mqtt_topic}/{base}'
 
     hass_device = {
-        "identifiers": [f'daly_bms'],
+        "identifiers": ['daly_bms'],
         "manufacturer": 'Daly',
         "model": 'Currently not available',
         "name": 'Daly BMS',
@@ -131,10 +131,10 @@ def mqtt_single_out(topic, data, retain=False):
     mqtt_client.publish(topic, data, retain=retain)
 
 
-def mqtt_iterator(base, result):
+def mqtt_iterator(result, base=''):
     for key in result.keys():
         if type(result[key]) == dict:
-            mqtt_iterator(f'{base}/{key}', result[key])
+            mqtt_iterator(result[key], f'{base}/{key}')
         else:
             if args.mqtt_hass:
                 logger.debug('Sending out hass discovery message')
@@ -146,7 +146,7 @@ def mqtt_iterator(base, result):
 
 def print_result(result):
     if args.mqtt:
-        mqtt_iterator('', result)
+        mqtt_iterator(result)
     else:
         print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -77,16 +77,23 @@ else:
 bms.connect(device=args.device)
 
 result = False
+def mqtt_on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
 
 def mqtt_on_publish(client, userdata, result):
     print("data published \n")
     print(json.dumps(result, indent=2))
     pass
 
+def mqtt_on_message(client, userdata, msg):
+    print(msg.topic+" "+str(msg.payload))
+
 if args.mqtt:
     mqtt_client = paho.Client("daly-bms", protocol=paho.MQTTv31)    
+    mqtt_client.on_connect = mqtt_on_connect
     mqtt_client.on_publish = mqtt_on_publish
-    mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
+    mqtt_client.on_message = mqtt_on_message
+    mqtt_client.connect(args.mqtt_broker, port=args.mqtt_port)
 
 def print_result(result):
     if args.mqtt:

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -3,6 +3,7 @@ import argparse
 import json
 import logging
 import sys
+import paho.mqtt.client as paho
 
 from dalybms import DalyBMS
 from dalybms import DalyBMSSinowealth
@@ -25,6 +26,31 @@ parser.add_argument("--check", help="Nagios style check", action="store_true")
 parser.add_argument("--set-discharge-mosfet", help="'on' or 'off'", type=str)
 parser.add_argument("--retry", help="retry X times if the request fails, default 5", type=int, default=5)
 parser.add_argument("--verbose", help="Verbose output", action="store_true")
+
+parser.add_argument("--mqtt", help="Write output to MQTT", action="store_true")
+
+parser.add_argument("--mqtt-topic", 
+                    help="MQTT topic to write to", 
+                    type=str)
+
+
+parser.add_argument("--mqtt-broker", 
+                    help="MQTT broker (server). default localhost", 
+                    type=str,
+                    default="localhost")
+
+parser.add_argument("--mqtt-port", 
+                    help="MQTT port. default 1883", 
+                    type=int,
+                    default=1883)
+
+parser.add_argument("--mqtt-user", 
+                    help="Username to authenticate MQTT with", 
+                    type=str)
+
+parser.add_argument("--mqtt-password", 
+                    help="Password to authenticate MQTT with", 
+                    type=str)
 
 args = parser.parse_args()
 
@@ -51,10 +77,15 @@ bms.connect(device=args.device)
 
 result = False
 
+if args.mqtt:
+    mqtt_client = paho.Client("daly-bms")    
+    mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
 
 def print_result(result):
-    print(json.dumps(result, indent=2))
+    if args.mqtt:
+        mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2))
 
+    print(json.dumps(result, indent=2))
 
 if args.status:
     result = bms.get_status()

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -84,13 +84,13 @@ def mqtt_on_publish(client, userdata, result):
     pass
 
 if args.mqtt:
-    mqtt_client = paho.Client("daly-bms")    
+    mqtt_client = paho.Client("daly-bms", protocol=MQTTv311)    
     mqtt_client.on_publish = mqtt_on_publish
     mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
 
 def print_result(result):
     if args.mqtt:
-        mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2), qos=0, retain=True)
+        ret = mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2), qos=0, retain=True)
 
     print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -89,10 +89,9 @@ def mqtt_on_message(client, userdata, msg):
     print(msg.topic+" "+str(msg.payload))
 
 if args.mqtt:
-    mqtt_client = paho.Client("daly-bms", protocol=paho.MQTTv31)    
-    mqtt_client.on_connect = mqtt_on_connect
-    mqtt_client.on_publish = mqtt_on_publish
-    mqtt_client.on_message = mqtt_on_message
+    mqtt_client = paho.Client()    
+    mqtt_client.enable_logger(logger)
+    mqtt_client.username_pw_set(args.mqtt_user, args.mqtt_password)
     mqtt_client.connect(args.mqtt_broker, port=args.mqtt_port)
 
 def print_result(result):

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -87,7 +87,7 @@ if args.mqtt:
 def print_result(result):
     if args.mqtt:
         for key in result.keys():
-            mqtt_client.publish(args.mqtt_topic + "/" + key, result[key])
+            mqtt_client.publish("/".join((args.mqtt_topic, str(key))), result[key])
 
     print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -84,7 +84,7 @@ def mqtt_on_publish(client, userdata, result):
     pass
 
 if args.mqtt:
-    mqtt_client = paho.Client("daly-bms", protocol=MQTTv311)    
+    mqtt_client = paho.Client("daly-bms", protocol=paho.MQTTv311)    
     mqtt_client.on_publish = mqtt_on_publish
     mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -3,7 +3,6 @@ import argparse
 import json
 import logging
 import sys
-import paho.mqtt.client as paho
 
 from dalybms import DalyBMS
 from dalybms import DalyBMSSinowealth
@@ -80,21 +79,77 @@ bms.connect(device=args.device)
 result = False
 
 if args.mqtt:
+    import paho.mqtt.client as paho
     mqtt_client = paho.Client()    
     mqtt_client.enable_logger(logger)
     mqtt_client.username_pw_set(args.mqtt_user, args.mqtt_password)
     mqtt_client.connect(args.mqtt_broker, port=args.mqtt_port)
 
+
+def build_mqtt_hass_config_discovery(base):
+    # Instead of daly_bms should be here added a proper name (unique), like serial or something
+    # At this point it can be used only one daly_bms system with hass discovery
+
+    hass_config_topic = f'homeassistant/sensor/daly_bms/{base.replace("/", "_")}/config'
+    hass_config_data = {}
+
+    hass_config_data["unique_id"] = f'daly_bms_{base.replace("/", "_")}'
+    hass_config_data["name"] = f'Daly BMS {base.replace("/", " ")}'
+
+    if 'soc_percent' in base:
+        hass_config_data["device_class"] = 'battery'
+        hass_config_data["unit_of_measurement"] = '%'
+    elif 'voltage' in base:
+        hass_config_data["device_class"] = 'voltage'
+        hass_config_data["unit_of_measurement"] = 'V'
+    elif 'current' in base:
+        hass_config_data["device_class"] = 'current'
+        hass_config_data["unit_of_measurement"] = 'A'
+    elif 'temperatures' in base:
+        hass_config_data["device_class"] = 'temperature'
+        hass_config_data["unit_of_measurement"] = '°C'
+    else:
+        pass
+
+    hass_config_data["json_attributes_topic"] = f'{args.mqtt_topic}/{base}'
+    hass_config_data["state_topic"] = f'{args.mqtt_topic}/{base}'
+
+    hass_device = {
+        "identifiers": [f'daly_bms'],
+        "manufacturer": 'Daly',
+        "model": 'Currently not available',
+        "name": 'Daly BMS',
+        "sw_version": 'Currently not available'
+    }
+    hass_config_data["device"] = hass_device
+
+    return hass_config_topic, json.dumps(hass_config_data)
+
+
+def mqtt_single_out(topic, data, retain=False):
+    logger.debug(f'Send data: {data} on topic: {topic}, retain flag: {retain}')
+    mqtt_client.publish(topic, data, retain=retain)
+
+
+def mqtt_iterator(base, result):
+    for key in result.keys():
+        if type(result[key]) == dict:
+            mqtt_iterator(f'{base}/{key}', result[key])
+        else:
+            if args.mqtt_hass:
+                logger.debug('Sending out hass discovery message')
+                topic, output = build_mqtt_hass_config_discovery(f'{base}/{key}')
+                mqtt_single_out(topic, output, retain=True)
+
+            mqtt_single_out(f'{args.mqtt_topic}{base}/{key}', result[key])
+
+
 def print_result(result):
     if args.mqtt:
-        for key in result.keys():
-            seq = (args.mqtt_topic, str(key))
-            if args.mqtt_hass:
-                seq = ("homeassistant", "sensor", args.mqtt_topic + "_" + str(key), "state")
+        mqtt_iterator('', result)
+    else:
+        print(json.dumps(result, indent=2))
 
-            mqtt_client.publish("/".join(seq), result[key])
-
-    print(json.dumps(result, indent=2))
 
 if args.status:
     result = bms.get_status()

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -84,7 +84,7 @@ def mqtt_on_publish(client, userdata, result):
     pass
 
 if args.mqtt:
-    mqtt_client = paho.Client("daly-bms", protocol=paho.MQTTv311)    
+    mqtt_client = paho.Client("daly-bms", protocol=paho.MQTTv31)    
     mqtt_client.on_publish = mqtt_on_publish
     mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -77,16 +77,6 @@ else:
 bms.connect(device=args.device)
 
 result = False
-def mqtt_on_connect(client, userdata, flags, rc):
-    print("Connected with result code "+str(rc))
-
-def mqtt_on_publish(client, userdata, result):
-    print("data published \n")
-    print(json.dumps(result, indent=2))
-    pass
-
-def mqtt_on_message(client, userdata, msg):
-    print(msg.topic+" "+str(msg.payload))
 
 if args.mqtt:
     mqtt_client = paho.Client()    
@@ -96,7 +86,8 @@ if args.mqtt:
 
 def print_result(result):
     if args.mqtt:
-        ret = mqtt_client.publish(args.mqtt_topic, json.dumps(result, indent=2), qos=0, retain=True)
+        for key in result.keys():
+            mqtt_client.publish(args.mqtt_topic + "/" + key, result[key])
 
     print(json.dumps(result, indent=2))
 

--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -78,8 +78,14 @@ bms.connect(device=args.device)
 
 result = False
 
+def mqtt_on_publish(client, userdata, result):
+    print("data published \n")
+    print(json.dumps(result, indent=2))
+    pass
+
 if args.mqtt:
     mqtt_client = paho.Client("daly-bms")    
+    mqtt_client.on_publish = mqtt_on_publish
     mqtt_client.connect(args.mqtt_broker, args.mqtt_port)
 
 def print_result(result):


### PR DESCRIPTION
I fixed some of the code of  brendanjerwin and added some more features regarding home assistant discovery.

Summary of my changes:
Fix --all option with --mqtt (It can handle unlimited depth of output dictionary)
Fix missing retain flag for hass discovery
Aggregate all sensors into one device in hass discovery
Add proper device_classes and units_of_measurements to hass discovery
Disable print output if mqtt is enabled
Add some debug statements
Only import module paho.mqtt if necessary


It imports the paho dependency now only if necessary as you mentioned at: https://github.com/dreadnought/python-daly-bms/pull/8