### PR TITLE
Sinowealth: Add more data

### DIFF
--- a/dalybms/daly_sinowealth.py
+++ b/dalybms/daly_sinowealth.py
@@ -167,7 +167,7 @@ class DalyBMSSinowealth:
 
         for key, value in responses.items():
             # change temperatures from Kelvin to °C
-            responses[key] = f'{(value-273):.2f}'
+            responses[key] = round(value-273, 2)
         return responses
 
     def get_status(self):
@@ -190,7 +190,7 @@ class DalyBMSSinowealth:
 
         for key, value in responses.items():
             if type(responses[key]) is float:
-                responses[key] = f'{value:.2f}'
+                responses[key] = round(value, 2)
 
         pack_response = self._read("15")
         pack_state = []
@@ -204,7 +204,7 @@ class DalyBMSSinowealth:
     def get_errors(self):
         response = self._read("16")
         pack_state = []
-        for key, value in self.PACK_STATUS.items():
+        for key, value in self.BATTERY_STATUS.items():
             if response[key] == "1":
                 pack_state.append(value)
 

--- a/dalybms/daly_sinowealth.py
+++ b/dalybms/daly_sinowealth.py
@@ -26,6 +26,34 @@ List from BMStool PC / Sinowealth
 
 
 class DalyBMSSinowealth:
+    PACK_STATUS = {
+        0: 'CAL: ',
+        5: 'VDQ: Valid Discharge Qualified',
+        6: 'FD: Fully Discharged',
+        7: 'FC: Fully Charged',
+        9: 'FAST_DSG: Fast Discharging',
+        10: 'MID_DSG: Medium Discharging',
+        11: 'SLOW_DSG: Slow Discharging',
+        12: 'DSGING: Discharging',
+        13: 'CHGING: Charging',
+        14: 'DSGMOS: Discharging enabled',
+        15: 'CHGMOS: Charging enabled',
+    }
+
+    BATTERY_STATUS = {
+        1: 'CTO',
+        2: 'AFE_SC: Short Circuit in AFE (Analog Front End)',
+        3: 'AFE_OV: Over Voltage in AFE (Analog Front End)',
+        4: 'UTD: Under Voltage in Discharge',
+        5: 'UTC: Under Voltage in Charge',
+        6: 'OTD: Over Voltage in Discharge',
+        7: 'OTC: Over Voltage in Charge',
+        12: 'OCD: Overcurrent Discharge',
+        13: 'OCC: Overcurrent Charge',
+        14: 'UV: Undervoltage',
+        15: 'OV: Overvoltage',
+    }
+
     def __init__(self, request_retries=3, logger=None):
         """
 
@@ -83,13 +111,13 @@ class DalyBMSSinowealth:
             self.logger.debug("empty response for command %s" % (command))
             return False
 
-        if len(response_data) == 5:
-            ctype = "i"
-        else:
-            ctype = "h"
-
         self.logger.debug("%s (%i)" % (response_data.hex(), len(response_data)))
-        return struct.unpack('>%s x' % ctype, response_data)[0]
+        if command in ("10", "11", "12"):
+            return struct.unpack('>i x', response_data)[0]
+        elif command in ("15", "16", "17", "18"):
+            return bin(int.from_bytes(response_data[:-1], byteorder='big'))[2:].zfill(16)
+        else:
+            return struct.unpack('>h x', response_data)[0]
 
     def get_cell_voltages(self):
         max_cells = 10
@@ -139,14 +167,48 @@ class DalyBMSSinowealth:
 
         for key, value in responses.items():
             # change temperatures from Kelvin to °C
-            responses[key] = value - 273
+            responses[key] = f'{(value-273):.2f}'
         return responses
 
     def get_status(self):
         requests = {
             "cycles": ("14", 1),
         }
-        return self._read_bulk(requests)
+        responses = self._read_bulk(requests)
+
+        for key, value in responses.items():
+            if type(responses[key]) is float:
+                responses[key] = int(value)
+        return responses
+
+    def get_mosfet_status(self):
+        requests = {
+            "full_capacity_ah": ("11", 1000),
+            "remaining_capacity_ah": ("12", 1000),
+        }
+        responses = self._read_bulk(requests)
+
+        for key, value in responses.items():
+            if type(responses[key]) is float:
+                responses[key] = f'{value:.2f}'
+
+        pack_response = self._read("15")
+        pack_state = []
+        for key, value in self.PACK_STATUS.items():
+            if pack_response[key] == "1":
+                pack_state.append(value)
+
+        responses['pack_state'] = pack_state
+        return responses
+
+    def get_errors(self):
+        response = self._read("16")
+        pack_state = []
+        for key, value in self.PACK_STATUS.items():
+            if response[key] == "1":
+                pack_state.append(value)
+
+        return pack_state
 
     # dummy functions for everything that is not supported by the Sinowealth BMS
     def get_cell_voltage_range(self):
@@ -155,13 +217,7 @@ class DalyBMSSinowealth:
     def get_temperature_range(self):
         return {}
 
-    def get_mosfet_status(self):
-        return {}
-
     def get_balancing_status(self):
-        return {}
-
-    def get_errors(self):
         return {}
 
     def get_all(self):
@@ -169,10 +225,10 @@ class DalyBMSSinowealth:
             "soc": self.get_soc(),
             #"cell_voltage_range": self.get_cell_voltage_range(),
             #"temperature_range": self.get_temperature_range(),
-            #"mosfet_status": self.get_mosfet_status(),
+            "mosfet_status": self.get_mosfet_status(),
             "status": self.get_status(),
             "cell_voltages": self.get_cell_voltages(),
             "temperatures": self.get_temperatures(),
             #"balancing_status": self.get_balancing_status(),
-            #"errors": self.get_errors()
+            "errors": self.get_errors()
         }


### PR DESCRIPTION
I have added the following items to the sinowealth implementation:
- full and remaining capacity
- pack_status (mosfet status about charging and discharging)
- errors (battery status)

Furthermore I format the number of the follwing
- temperature: two digits after dot instead of up to 16 or so (float)
- cycles: int instead float

I tried to put the new values (capacities, battery status and pack status) in the same categories like on the daly implementation, although it was not clear for me what is status vs mosfet_status.