### PR TITLE
Fix mqtt error with lists of error and pack_status

### DIFF
--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -111,8 +111,8 @@ def build_mqtt_hass_config_discovery(base):
     else:
         pass
 
-    hass_config_data["json_attributes_topic"] = f'{args.mqtt_topic}/{base}'
-    hass_config_data["state_topic"] = f'{args.mqtt_topic}/{base}'
+    hass_config_data["json_attributes_topic"] = f'{args.mqtt_topic}{base}'
+    hass_config_data["state_topic"] = f'{args.mqtt_topic}{base}'
 
     hass_device = {
         "identifiers": ['daly_bms'],
@@ -141,7 +141,12 @@ def mqtt_iterator(result, base=''):
                 topic, output = build_mqtt_hass_config_discovery(f'{base}/{key}')
                 mqtt_single_out(topic, output, retain=True)
 
-            mqtt_single_out(f'{args.mqtt_topic}{base}/{key}', result[key])
+            if type(result[key]) == list:
+                val = json.dumps(result[key])
+            else:
+                val = result[key]
+
+            mqtt_single_out(f'{args.mqtt_topic}{base}/{key}', val)
 
 
 def print_result(result):


### PR DESCRIPTION
The PR https://github.com/dreadnought/python-daly-bms/pull/14 breaks my mqtt PR from yesterday, as there are lists which needs to be outputted via mqtt. 
Furthermore this contains a small fix for mqtt hass discovery. Due to the empty base from start iterator, it was had a double slash in topic.

Sorry I just not crosschecked the two PR yesterday against each other...