### PR TITLE
Do not set highest/lowest cell hass class to be voltage. Add hass device class for capacity

### DIFF
--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -101,7 +101,7 @@ def build_mqtt_hass_config_discovery(base):
     if 'soc_percent' in base:
         hass_config_data["device_class"] = 'battery'
         hass_config_data["unit_of_measurement"] = '%'
-    elif 'voltage' in base:
+    elif 'voltage' in base and not ('lowest_cell' in base or 'highest_cell' in base):
         hass_config_data["device_class"] = 'voltage'
         hass_config_data["unit_of_measurement"] = 'V'
     elif 'current' in base:
@@ -110,6 +110,9 @@ def build_mqtt_hass_config_discovery(base):
     elif 'temperatures' in base:
         hass_config_data["device_class"] = 'temperature'
         hass_config_data["unit_of_measurement"] = '°C'
+    elif 'capacity' in 'base':
+        hass_config_data["device_class"] = 'energy'
+        hass_config_data["unit_of_measurement"] = 'Ah'
     else:
         pass
 


### PR DESCRIPTION
This PR fixed a couple issues for me in Home Assistant. 
It moved the highest cell number and lowest cell number to not be a voltage. This fixed an issue when viewing all voltages in hass history. Now highest/lowest cells are more like the other statuses.
![image](https://user-images.githubusercontent.com/1399456/210184550-a0dedba2-999e-46a6-aead-ed38cae988b7.png)
![image](https://user-images.githubusercontent.com/1399456/210184563-54881e41-95db-4baa-b1e7-d66168337414.png)

It also adjusted the capacity to have a device class of "energy", which allows for better charts.
![image](https://user-images.githubusercontent.com/1399456/210184596-98d40d2f-8ef5-440d-b74c-9eafd8d46104.png)
