### PR TITLE
Add loop_start to ensure all messages are published

### DIFF
--- a/bin/daly-bms-cli
+++ b/bin/daly-bms-cli
@@ -88,7 +88,7 @@ if args.mqtt:
     mqtt_client.enable_logger(logger)
     mqtt_client.username_pw_set(args.mqtt_user, args.mqtt_password)
     mqtt_client.connect(args.mqtt_broker, port=args.mqtt_port)
-
+    mqtt_client.loop_start()
 
 def build_mqtt_hass_config_discovery(base):
     # Instead of daly_bms should be here added a proper name (unique), like serial or something


### PR DESCRIPTION
I was having an issue where I could see all the messages being published in the debug logs but not all the messages made it to the broker.  When using the `--all` flag the first few messages would make it but I would only get down to temperature messages occasionally.  The MQTT broker would log `Socket error on client <client id>, disconnecting.` presumably before the client finished publishing all messages.  This was happening over a somewhat compromised WiFi connection on older hardware.

Adding `loop_start()` resolved the issue for me. I'm now getting all data and I no longer get errors in the broker log.